### PR TITLE
feat(gateway): Add websocket error types

### DIFF
--- a/contracts/gateway/src/main.ts
+++ b/contracts/gateway/src/main.ts
@@ -5,3 +5,4 @@ export { WsClient } from './services/ws/client';
 export * from './services/ws/contract';
 export * from './services/http/contract';
 export * from './services/errors';
+export * from './services/ws/errors';

--- a/contracts/gateway/src/services/ws/errors.ts
+++ b/contracts/gateway/src/services/ws/errors.ts
@@ -1,0 +1,43 @@
+import type { ServiceErrorContext } from '@ez4/common';
+
+import { ServiceError } from '@ez4/common';
+
+/**
+ * Default WS error.
+ */
+export class WsError extends ServiceError {
+  constructor(
+    public code: number,
+    message: string,
+    context?: ServiceErrorContext
+  ) {
+    super(message, context);
+  }
+}
+
+/**
+ * WS Unauthorized error.
+ */
+export class WsUnauthorizedError extends WsError {
+  constructor(message?: string, context?: ServiceErrorContext) {
+    super(4001, message || 'Unauthorized', context);
+  }
+}
+
+/**
+ * WS Forbidden error.
+ */
+export class WsForbiddenError extends WsError {
+  constructor(message?: string, context?: ServiceErrorContext) {
+    super(4003, message || 'Forbidden', context);
+  }
+}
+
+/**
+ * WS Internal Server error.
+ */
+export class WsInternalServerError extends WsError {
+  constructor(message?: string, context?: ServiceErrorContext) {
+    super(4500, message || 'Internal server error', context);
+  }
+}

--- a/contracts/gateway/src/utils/errors.ts
+++ b/contracts/gateway/src/utils/errors.ts
@@ -8,7 +8,11 @@ import {
   HttpConflictError,
   HttpUnsupportedMediaTypeError,
   HttpUnprocessableEntityError,
-  HttpError
+  HttpError,
+  WsUnauthorizedError,
+  WsForbiddenError,
+  WsInternalServerError,
+  WsError
 } from '@ez4/gateway';
 
 /**
@@ -60,5 +64,29 @@ export const getHttpException = (status: number, message: string, context?: Serv
 
     default:
       return new HttpError(status, message, context);
+  }
+};
+
+/**
+ * Get an exception based on the given WS close code.
+ *
+ * @param code WS close code.
+ * @param message Exception message.
+ * @param context Exception context.
+ * @returns Returns the corresponding exception.
+ */
+export const getWsException = (code: number, message: string, context?: ServiceErrorContext) => {
+  switch (code) {
+    case 4001:
+      return new WsUnauthorizedError(message, context);
+
+    case 4003:
+      return new WsForbiddenError(message, context);
+
+    case 4500:
+      return new WsInternalServerError(message, context);
+
+    default:
+      return new WsError(code, message, context);
   }
 };

--- a/contracts/gateway/test/ws-errors.spec.ts
+++ b/contracts/gateway/test/ws-errors.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import { ok, equal, deepEqual } from 'node:assert/strict';
+
+import { WsError, WsUnauthorizedError, WsForbiddenError, WsInternalServerError } from '@ez4/gateway';
+
+import { getWsException } from '@ez4/gateway/utils';
+
+describe('ws errors', () => {
+  it('assert :: WsError base class', () => {
+    const error = new WsError(4000, 'custom error');
+
+    ok(error instanceof Error);
+    equal(error.code, 4000);
+    equal(error.message, 'custom error');
+  });
+
+  it('assert :: WsError with context', () => {
+    const context = { field: 'token' };
+    const error = new WsError(4000, 'custom error', context);
+
+    equal(error.code, 4000);
+    equal(error.message, 'custom error');
+    deepEqual(error.context, context);
+  });
+
+  it('assert :: WsUnauthorizedError defaults', () => {
+    const error = new WsUnauthorizedError();
+
+    ok(error instanceof WsError);
+    equal(error.code, 4001);
+    equal(error.message, 'Unauthorized');
+  });
+
+  it('assert :: WsUnauthorizedError custom message', () => {
+    const error = new WsUnauthorizedError('Token expired');
+
+    equal(error.code, 4001);
+    equal(error.message, 'Token expired');
+  });
+
+  it('assert :: WsForbiddenError defaults', () => {
+    const error = new WsForbiddenError();
+
+    ok(error instanceof WsError);
+    equal(error.code, 4003);
+    equal(error.message, 'Forbidden');
+  });
+
+  it('assert :: WsForbiddenError custom message', () => {
+    const error = new WsForbiddenError('Insufficient permissions');
+
+    equal(error.code, 4003);
+    equal(error.message, 'Insufficient permissions');
+  });
+
+  it('assert :: WsInternalServerError defaults', () => {
+    const error = new WsInternalServerError();
+
+    ok(error instanceof WsError);
+    equal(error.code, 4500);
+    equal(error.message, 'Internal server error');
+  });
+
+  it('assert :: WsInternalServerError custom message', () => {
+    const error = new WsInternalServerError('Something broke');
+
+    equal(error.code, 4500);
+    equal(error.message, 'Something broke');
+  });
+});
+
+describe('getWsException', () => {
+  it('assert :: returns WsUnauthorizedError for code 4001', () => {
+    const error = getWsException(4001, 'bad token');
+
+    ok(error instanceof WsUnauthorizedError);
+    equal(error.code, 4001);
+    equal(error.message, 'bad token');
+  });
+
+  it('assert :: returns WsForbiddenError for code 4003', () => {
+    const error = getWsException(4003, 'no access');
+
+    ok(error instanceof WsForbiddenError);
+    equal(error.code, 4003);
+    equal(error.message, 'no access');
+  });
+
+  it('assert :: returns WsInternalServerError for code 4500', () => {
+    const error = getWsException(4500, 'server broke');
+
+    ok(error instanceof WsInternalServerError);
+    equal(error.code, 4500);
+    equal(error.message, 'server broke');
+  });
+
+  it('assert :: returns base WsError for unknown code', () => {
+    const error = getWsException(4999, 'custom');
+
+    ok(error instanceof WsError);
+    ok(!(error instanceof WsUnauthorizedError));
+    ok(!(error instanceof WsForbiddenError));
+    ok(!(error instanceof WsInternalServerError));
+    equal(error.code, 4999);
+    equal(error.message, 'custom');
+  });
+
+  it('assert :: passes context through', () => {
+    const context = { detail: 'expired' };
+    const error = getWsException(4001, 'bad token', context);
+
+    deepEqual(error.context, context);
+  });
+});

--- a/examples/aws-gateway-websocket/src/authorizers/token.ts
+++ b/examples/aws-gateway-websocket/src/authorizers/token.ts
@@ -1,7 +1,7 @@
 import type { Ws } from '@ez4/gateway';
 import type { Identity } from './types';
 
-import { HttpForbiddenError } from '@ez4/gateway';
+import { WsForbiddenError } from '@ez4/gateway';
 
 const SUPER_SECRET_API_KEY = 'query-api-key';
 
@@ -28,7 +28,7 @@ export function tokenAuthorizer(request: AuthorizerRequest): AuthorizerResponse 
   const { token } = request.query;
 
   if (token !== SUPER_SECRET_API_KEY) {
-    throw new HttpForbiddenError();
+    throw new WsForbiddenError();
   }
 
   return {

--- a/providers/aws/aws-gateway/lib/authorizer.ts
+++ b/providers/aws/aws-gateway/lib/authorizer.ts
@@ -12,7 +12,7 @@ import type {
 } from 'aws-lambda';
 
 import { resolveHeaders, resolvePathParameters, resolveQueryStrings, resolveValidation } from '@ez4/gateway/utils';
-import { HttpForbiddenError, HttpUnauthorizedError } from '@ez4/gateway';
+import { HttpForbiddenError, HttpUnauthorizedError, WsError, WsInternalServerError } from '@ez4/gateway';
 import { ServiceEventType, Runtime } from '@ez4/common';
 import { getRandomUUID } from '@ez4/utils';
 
@@ -27,6 +27,7 @@ declare const __EZ4_PARAMETERS_SCHEMA: ObjectSchema | null;
 declare const __EZ4_QUERY_SCHEMA: ObjectSchema | null;
 declare const __EZ4_PREFERENCES: HttpPreferences;
 declare const __EZ4_CONTEXT: object;
+declare const __EZ4_WS_ERROR_FORWARDING: boolean;
 
 declare function handle(request: IncomingRequest, context: object): Promise<Http.AuthResponse>;
 declare function dispatch(event: ServiceEvent, context: object): Promise<void>;
@@ -71,12 +72,28 @@ export async function apiEntryPoint(event: RequestEvent, context: Context): Prom
   } catch (error) {
     await onError(error, request);
 
+    if (__EZ4_WS_ERROR_FORWARDING && error instanceof WsError) {
+      return getAuthorizationResponse(true, resourceArn, {
+        __ez4_auth_error: error.message,
+        __ez4_auth_code: String(error.code)
+      });
+    }
+
     if (error instanceof HttpForbiddenError) {
       return getAuthorizationResponse(false, resourceArn);
     }
 
     if (error instanceof HttpUnauthorizedError) {
       throw 'Unauthorized';
+    }
+
+    if (__EZ4_WS_ERROR_FORWARDING) {
+      const fallback = new WsInternalServerError();
+
+      return getAuthorizationResponse(true, resourceArn, {
+        __ez4_auth_error: fallback.message,
+        __ez4_auth_code: String(fallback.code)
+      });
     }
 
     throw error;

--- a/providers/aws/aws-gateway/lib/connection.ts
+++ b/providers/aws/aws-gateway/lib/connection.ts
@@ -204,19 +204,21 @@ export const getSuccessResponse = (traceId: string): ResponseEvent => {
   };
 };
 
-export const getConnectionEndpoint = (domainName: string, stage: string) => {
+export const getConnectionEndpoint = (domainName: string, stage: string, rawPath: string) => {
   if (domainName.includes('.execute-api.')) {
     return `https://${domainName}/${stage}`;
   }
 
-  return `https://${domainName}`;
+  const mappingPath = rawPath.replace(/\/\$connect$/, '').replace(/\/$/, '');
+
+  return `https://${domainName}${mappingPath}`;
 };
 
 const sendAuthError = async (event: RequestEvent, error: { message: string; code: number }) => {
   const { domainName, stage, connectionId } = event.requestContext;
 
   const client = new ApiGatewayManagementApiClient({
-    endpoint: getConnectionEndpoint(domainName, stage)
+    endpoint: getConnectionEndpoint(domainName, stage, event.rawPath)
   });
 
   try {

--- a/providers/aws/aws-gateway/lib/connection.ts
+++ b/providers/aws/aws-gateway/lib/connection.ts
@@ -11,6 +11,8 @@ import type {
   Context
 } from 'aws-lambda';
 
+import { ApiGatewayManagementApiClient, PostToConnectionCommand, DeleteConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+
 import { resolveHeaders, resolveIdentity, resolveQueryStrings, resolveValidation } from '@ez4/gateway/utils';
 import { ServiceEventType, Runtime } from '@ez4/common';
 import { getRandomUUID } from '@ez4/utils';
@@ -25,6 +27,7 @@ declare const __EZ4_QUERY_SCHEMA: ObjectSchema | null;
 declare const __EZ4_IDENTITY_SCHEMA: ObjectSchema | UnionSchema | null;
 declare const __EZ4_PREFERENCES: HttpPreferences;
 declare const __EZ4_CONTEXT: object;
+declare const __EZ4_WS_ERROR_FORWARDING: boolean;
 
 declare function dispatch(event: Ws.ServiceEvent<Ws.Event>, context: object): Promise<void>;
 declare function handle(request: Ws.Incoming<Ws.Event>, context: object): Promise<void>;
@@ -47,6 +50,21 @@ export async function apiEntryPoint(event: RequestEvent, context: Context): Prom
   Runtime.setScope({
     traceId
   });
+
+  if (__EZ4_WS_ERROR_FORWARDING) {
+    const authError = getAuthError(event);
+
+    if (authError) {
+      await sendAuthError(event, authError);
+
+      return {
+        statusCode: authError.code,
+        headers: {
+          ['x-trace-id']: traceId
+        }
+      };
+    }
+  }
 
   try {
     await onBegin(request);
@@ -172,4 +190,52 @@ const onEnd = async (request: Ws.Incoming<Ws.Event>) => {
     },
     __EZ4_CONTEXT
   );
+};
+
+const getAuthError = (event: RequestEvent) => {
+  const authorizer = event.requestContext?.authorizer;
+
+  if (!authorizer?.__ez4_auth_error) {
+    return undefined;
+  }
+
+  return {
+    message: String(authorizer.__ez4_auth_error),
+    code: Number(authorizer.__ez4_auth_code) || 4500
+  };
+};
+
+const sendAuthError = async (event: RequestEvent, error: { message: string; code: number }) => {
+  const { domainName, stage, connectionId } = event.requestContext;
+
+  const client = new ApiGatewayManagementApiClient({
+    endpoint: `https://${domainName}/${stage}`
+  });
+
+  try {
+    await client.send(
+      new PostToConnectionCommand({
+        ConnectionId: connectionId,
+        Data: Buffer.from(
+          JSON.stringify({
+            type: 'error',
+            message: error.message,
+            code: error.code
+          })
+        )
+      })
+    );
+  } catch {
+    // Connection may already be gone
+  }
+
+  try {
+    await client.send(
+      new DeleteConnectionCommand({
+        ConnectionId: connectionId
+      })
+    );
+  } catch {
+    // Connection may already be gone
+  }
 };

--- a/providers/aws/aws-gateway/lib/connection.ts
+++ b/providers/aws/aws-gateway/lib/connection.ts
@@ -57,12 +57,7 @@ export async function apiEntryPoint(event: RequestEvent, context: Context): Prom
     if (authError) {
       await sendAuthError(event, authError);
 
-      return {
-        statusCode: authError.code,
-        headers: {
-          ['x-trace-id']: traceId
-        }
-      };
+      return getSuccessResponse(traceId);
     }
   }
 
@@ -77,12 +72,7 @@ export async function apiEntryPoint(event: RequestEvent, context: Context): Prom
 
     await onDone(request);
 
-    return {
-      statusCode: 204,
-      headers: {
-        ['x-trace-id']: traceId
-      }
-    };
+    return getSuccessResponse(traceId);
 
     //
   } catch (error) {
@@ -205,11 +195,28 @@ const getAuthError = (event: RequestEvent) => {
   };
 };
 
+export const getSuccessResponse = (traceId: string): ResponseEvent => {
+  return {
+    statusCode: 204,
+    headers: {
+      ['x-trace-id']: traceId
+    }
+  };
+};
+
+export const getConnectionEndpoint = (domainName: string, stage: string) => {
+  if (domainName.includes('.execute-api.')) {
+    return `https://${domainName}/${stage}`;
+  }
+
+  return `https://${domainName}`;
+};
+
 const sendAuthError = async (event: RequestEvent, error: { message: string; code: number }) => {
   const { domainName, stage, connectionId } = event.requestContext;
 
   const client = new ApiGatewayManagementApiClient({
-    endpoint: `https://${domainName}/${stage}`
+    endpoint: getConnectionEndpoint(domainName, stage)
   });
 
   try {

--- a/providers/aws/aws-gateway/src/authorizer/function/bundler.ts
+++ b/providers/aws/aws-gateway/src/authorizer/function/bundler.ts
@@ -12,7 +12,8 @@ import { AuthorizerServiceName } from '../types';
 declare const __MODULE_PATH: string;
 
 export const bundleApiFunction = async (parameters: AuthorizerFunctionParameters, connections: EntryState[]) => {
-  const { services, context, debug, authorizer, listener, headersSchema, parametersSchema, querySchema, preferences } = parameters;
+  const { services, context, debug, authorizer, listener, headersSchema, parametersSchema, querySchema, preferences, wsErrorForwarding } =
+    parameters;
 
   const definitions = getDefinitionsObject(connections);
 
@@ -25,7 +26,8 @@ export const bundleApiFunction = async (parameters: AuthorizerFunctionParameters
       __EZ4_HEADERS_SCHEMA: headersSchema ? JSON.stringify(headersSchema) : 'undefined',
       __EZ4_PARAMETERS_SCHEMA: parametersSchema ? JSON.stringify(parametersSchema) : 'undefined',
       __EZ4_QUERY_SCHEMA: querySchema ? JSON.stringify(querySchema) : 'undefined',
-      __EZ4_PREFERENCES: preferences ? JSON.stringify(preferences) : 'undefined'
+      __EZ4_PREFERENCES: preferences ? JSON.stringify(preferences) : 'undefined',
+      __EZ4_WS_ERROR_FORWARDING: wsErrorForwarding ? 'true' : 'false'
     },
     handler: authorizer,
     listener,

--- a/providers/aws/aws-gateway/src/authorizer/function/types.ts
+++ b/providers/aws/aws-gateway/src/authorizer/function/types.ts
@@ -27,4 +27,5 @@ export type AuthorizerFunctionParameters = Omit<
   variables: (LinkedVariables | undefined)[];
   services?: LinkedServices;
   debug?: boolean;
+  wsErrorForwarding?: boolean;
 };

--- a/providers/aws/aws-gateway/src/integration/function/bundler.ts
+++ b/providers/aws/aws-gateway/src/integration/function/bundler.ts
@@ -54,7 +54,8 @@ export const bundleRequestFunction = async (parameters: IntegrationFunctionParam
 };
 
 export const bundleConnectionFunction = async (parameters: IntegrationFunctionParameters, connections: EntryState[]) => {
-  const { services, handler, listener, preferences, headersSchema, querySchema, identitySchema, context, debug } = parameters;
+  const { services, handler, listener, preferences, headersSchema, querySchema, identitySchema, wsErrorForwarding, context, debug } =
+    parameters;
 
   const definitions = getDefinitionsObject(connections);
 
@@ -67,7 +68,8 @@ export const bundleConnectionFunction = async (parameters: IntegrationFunctionPa
       __EZ4_HEADERS_SCHEMA: headersSchema ? JSON.stringify(headersSchema) : 'undefined',
       __EZ4_QUERY_SCHEMA: querySchema ? JSON.stringify(querySchema) : 'undefined',
       __EZ4_IDENTITY_SCHEMA: identitySchema ? JSON.stringify(identitySchema) : 'undefined',
-      __EZ4_PREFERENCES: preferences ? JSON.stringify(preferences) : 'undefined'
+      __EZ4_PREFERENCES: preferences ? JSON.stringify(preferences) : 'undefined',
+      __EZ4_WS_ERROR_FORWARDING: wsErrorForwarding ? 'true' : 'false'
     },
     handler,
     listener,

--- a/providers/aws/aws-gateway/src/integration/function/types.ts
+++ b/providers/aws/aws-gateway/src/integration/function/types.ts
@@ -32,6 +32,7 @@ export type IntegrationFunctionParameters = Omit<
   variables: (LinkedVariables | undefined)[];
   services?: LinkedServices;
   debug?: boolean;
+  wsErrorForwarding?: boolean;
 };
 
 export const enum IntegrationFunctionType {

--- a/providers/aws/aws-gateway/src/triggers/authorizer.ts
+++ b/providers/aws/aws-gateway/src/triggers/authorizer.ts
@@ -5,7 +5,7 @@ import type { ObjectSchema } from '@ez4/schema';
 import type { GatewayState } from '../gateway/types';
 
 import { tryGetFunctionState } from '@ez4/aws-function';
-import { isHttpService } from '@ez4/gateway/library';
+import { isHttpService, isWsService } from '@ez4/gateway/library';
 import { isRoleState } from '@ez4/aws-identity';
 import { createLogGroup } from '@ez4/aws-logs';
 import { deepMerge } from '@ez4/utils';
@@ -83,6 +83,7 @@ export const getAuthorizerFunction = (
       files,
       debug,
       vpc,
+      wsErrorForwarding: isWsService(service),
       preferences: {
         ...service.defaults?.preferences,
         ...target.preferences

--- a/providers/aws/aws-gateway/src/triggers/integration.ts
+++ b/providers/aws/aws-gateway/src/triggers/integration.ts
@@ -120,6 +120,7 @@ const getIntegrationFunction = (
       files,
       debug,
       vpc,
+      wsErrorForwarding: type === IntegrationFunctionType.WsConnection,
       handler: {
         sourceFile: handler.file,
         functionName: handler.name,

--- a/providers/aws/aws-gateway/test/connection.spec.ts
+++ b/providers/aws/aws-gateway/test/connection.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import { deepEqual, equal } from 'node:assert/strict';
+
+import { getConnectionEndpoint, getSuccessResponse } from '../lib/connection.ts';
+
+describe('gateway connection', () => {
+  it('assert :: returns success response for forwarded auth errors', () => {
+    deepEqual(getSuccessResponse('trace-id'), {
+      statusCode: 204,
+      headers: {
+        ['x-trace-id']: 'trace-id'
+      }
+    });
+  });
+
+  it('assert :: includes stage for execute-api domains', () => {
+    equal(
+      getConnectionEndpoint('abc123.execute-api.us-east-1.amazonaws.com', 'prod'),
+      'https://abc123.execute-api.us-east-1.amazonaws.com/prod'
+    );
+  });
+
+  it('assert :: omits stage for custom domains', () => {
+    equal(getConnectionEndpoint('ws.example.com', 'prod'), 'https://ws.example.com');
+  });
+});

--- a/providers/aws/aws-gateway/test/connection.spec.ts
+++ b/providers/aws/aws-gateway/test/connection.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import { deepEqual, equal } from 'node:assert/strict';
 
-import { getConnectionEndpoint, getSuccessResponse } from '../lib/connection.ts';
+import { getConnectionEndpoint, getSuccessResponse } from '../lib/connection';
 
 describe('gateway connection', () => {
   it('assert :: returns success response for forwarded auth errors', () => {
@@ -15,12 +15,20 @@ describe('gateway connection', () => {
 
   it('assert :: includes stage for execute-api domains', () => {
     equal(
-      getConnectionEndpoint('abc123.execute-api.us-east-1.amazonaws.com', 'prod'),
+      getConnectionEndpoint('abc123.execute-api.us-east-1.amazonaws.com', 'prod', '/prod'),
       'https://abc123.execute-api.us-east-1.amazonaws.com/prod'
     );
   });
 
-  it('assert :: omits stage for custom domains', () => {
-    equal(getConnectionEndpoint('ws.example.com', 'prod'), 'https://ws.example.com');
+  it('assert :: preserves mapping path for custom domains', () => {
+    equal(getConnectionEndpoint('ws.example.com', 'prod', '/tenant-a'), 'https://ws.example.com/tenant-a');
+  });
+
+  it('assert :: strips connect route from custom-domain paths', () => {
+    equal(getConnectionEndpoint('ws.example.com', 'prod', '/tenant-a/$connect'), 'https://ws.example.com/tenant-a');
+  });
+
+  it('assert :: omits path for root custom domains', () => {
+    equal(getConnectionEndpoint('ws.example.com', 'prod', '/'), 'https://ws.example.com');
   });
 });

--- a/providers/aws/aws-gateway/tsconfig.test.json
+++ b/providers/aws/aws-gateway/tsconfig.test.json
@@ -2,10 +2,8 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "noEmit": true
+    "noEmit": true,
+    "allowImportingTsExtensions": true
   },
-  "include": [
-    "./src",
-    "./test"
-  ]
+  "include": ["./lib", "./src", "./test"]
 }

--- a/providers/aws/aws-gateway/tsconfig.test.json
+++ b/providers/aws/aws-gateway/tsconfig.test.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "noEmit": true,
-    "allowImportingTsExtensions": true
+    "noEmit": true
   },
   "include": ["./lib", "./src", "./test"]
 }


### PR DESCRIPTION
## Summary

This PR adds WebSocket auth error forwarding for AWS API Gateway WebSocket services.

Before this change, if the authorizer rejected the connection during the handshake, the client usually got a pretty useless failure back. Sometimes it looked like a generic disconnect. Sometimes it looked like the socket never connected in the first place. Either way, the frontend did not get enough information to tell "your token is bad" from "the connection dropped."

The new flow keeps the connection path alive long enough to send a structured error to the client, then closes the socket deliberately. It also adds WebSocket-specific gateway errors, wires the forwarding flag through the AWS gateway runtime, and updates the example authorizer to use the new error types.

## Why

The main reason is client behavior.

A handshake failure is technically fine from the gateway's point of view, but it is a bad interface for a WebSocket client. The frontend sees a failed connection and has to guess what happened. That guess matters. A network hiccup should trigger reconnect logic. An expired token should probably trigger re-auth. A forbidden action should stop retrying and show the right message.

Without error forwarding, all of those cases collapse into the same vague failure.

With forwarding enabled, the backend can send an actual auth error before disconnecting. That gives the client something real to work with. It also makes debugging much less frustrating, because you can see whether the failure was `unauthorized`, `forbidden`, or an internal error instead of staring at a dead socket and inferring the rest.

That is really the whole point here: WebSocket auth failures need to be explicit. If they only exist inside the handshake, the client never gets the part it actually needs.

## What changed

- add `WsError`, `WsUnauthorizedError`, `WsForbiddenError`, and `WsInternalServerError`
- add `getWsException` for close-code-to-error mapping
- allow AWS WebSocket authorizers to forward `WsError` details through authorizer context
- update the connection handler to send the forwarded error message and then disconnect the client
- keep the connect response valid for API Gateway while still forwarding the auth error
- preserve custom-domain API mapping paths when building the management API endpoint
- update the WebSocket example authorizer to throw `WsForbiddenError`

## Behavior

Before:

- A rejected WebSocket authorizer response could surface as an opaque client-side failure
- The client could not reliably tell `forbidden` from `network error`
- Custom-domain setups with API mapping paths could miss forwarded auth errors entirely

After:

- The authorizer can forward a structured WebSocket auth error
- The connection handler sends that payload to the client
- The socket is closed on purpose after the error is sent
- Custom domains with API mapping paths still target the correct management API endpoint