### PR TITLE
feat(database): add isMissingOrNull where operator

### DIFF
--- a/contracts/database/src/services/query.ts
+++ b/contracts/database/src/services/query.ts
@@ -189,6 +189,7 @@ export namespace Query {
     | WhereBetween<V>
     | WhereIsMissing
     | WhereIsNull
+    | WhereIsMissingOrNull
     | WhereStartsWith<E>
     | WhereContains<V, E>;
 
@@ -254,6 +255,7 @@ export namespace Query {
     WhereBetween<any> &
     WhereIsMissing &
     WhereIsNull &
+    WhereIsMissingOrNull &
     WhereStartsWith<never> &
     WhereContains<any, never>);
 
@@ -325,6 +327,13 @@ export namespace Query {
      * Check whether the entity value is null.
      */
     isNull: boolean;
+  };
+
+  type WhereIsMissingOrNull = {
+    /**
+     * Check whether the entity value is missing or null.
+     */
+    isMissingOrNull: boolean;
   };
 
   type WhereStartsWith<E extends DatabaseEngine> = InsensitiveModeUtils.Input<E> & {

--- a/libraries/pgclient/test/query/where-json-missing.spec.ts
+++ b/libraries/pgclient/test/query/where-json-missing.spec.ts
@@ -70,4 +70,32 @@ describe('where json missing', () => {
 
     deepEqual(variables, []);
   });
+
+  it('assert :: prepare where json missing or null (operator)', () => {
+    const [whereClause, variables] = getWhereOperation({
+      json: {
+        number: {
+          isMissingOrNull: true
+        }
+      }
+    });
+
+    equal(whereClause, `WHERE (NOT ("json" ? 'number') OR "json"->>'number' IS null)`);
+
+    deepEqual(variables, []);
+  });
+
+  it('assert :: prepare where json not missing or null (operator)', () => {
+    const [whereClause, variables] = getWhereOperation({
+      json: {
+        number: {
+          isMissingOrNull: false
+        }
+      }
+    });
+
+    equal(whereClause, `WHERE ("json" ? 'number' AND "json"->>'number' IS NOT null)`);
+
+    deepEqual(variables, []);
+  });
 });

--- a/libraries/pgclient/test/query/where-missing.spec.ts
+++ b/libraries/pgclient/test/query/where-missing.spec.ts
@@ -66,4 +66,28 @@ describe('where missing', () => {
 
     deepEqual(variables, []);
   });
+
+  it('assert :: prepare where missing or null (operator)', () => {
+    const [whereClause, variables] = getWhereOperation({
+      string: {
+        isMissingOrNull: true
+      }
+    });
+
+    equal(whereClause, `WHERE "string" IS null`);
+
+    deepEqual(variables, []);
+  });
+
+  it('assert :: prepare where not missing or null (operator)', () => {
+    const [whereClause, variables] = getWhereOperation({
+      string: {
+        isMissingOrNull: false
+      }
+    });
+
+    equal(whereClause, `WHERE "string" IS NOT null`);
+
+    deepEqual(variables, []);
+  });
 });

--- a/libraries/pgsql/src/common/types.ts
+++ b/libraries/pgsql/src/common/types.ts
@@ -20,6 +20,7 @@ export const enum SqlOperator {
   IsBetween = 'isBetween',
   IsMissing = 'isMissing',
   IsNull = 'isNull',
+  IsMissingOrNull = 'isMissingOrNull',
   StartsWith = 'startsWith',
   Contains = 'contains'
 }

--- a/libraries/pgsql/src/operations/conditions.ts
+++ b/libraries/pgsql/src/operations/conditions.ts
@@ -25,6 +25,7 @@ import { getIsBetweenOperation } from './is-between';
 import { getStartsWithOperation } from './starts-with';
 import { getContainsOperation } from './contains';
 import { getIsMissingOperation } from './is-missing';
+import { getIsMissingOrNullOperation } from './is-missing-or-null';
 
 import { InvalidOperandError, MissingOperatorError } from './errors';
 
@@ -221,6 +222,9 @@ const getFinalOperation = (column: string, schema: AnySchema | undefined, operat
 
     case SqlOperator.IsMissing:
       return getIsMissingOperation(column, operand, context);
+
+    case SqlOperator.IsMissingOrNull:
+      return getIsMissingOrNullOperation(column, operand, context);
 
     case SqlOperator.Equal:
       return getEqualOperation(column, schema, operand, context);

--- a/libraries/pgsql/src/operations/is-missing-or-null.ts
+++ b/libraries/pgsql/src/operations/is-missing-or-null.ts
@@ -1,0 +1,18 @@
+import type { SqlOperationContext } from './types';
+
+import { escapeSqlText } from '../utils/escape';
+import { getIsNullOperation } from './is-null';
+
+export const getIsMissingOrNullOperation = (column: string, operand: unknown, context: SqlOperationContext) => {
+  if (!context.path || !context.field) {
+    return getIsNullOperation(column, operand);
+  }
+
+  const hasKey = `${context.path} ? ${escapeSqlText(context.field)}`;
+
+  if (operand) {
+    return `(NOT (${hasKey}) OR ${column} IS null)`;
+  }
+
+  return `(${hasKey} AND ${column} IS NOT null)`;
+};

--- a/providers/aws/aws-dynamodb/src/client/common/where.ts
+++ b/providers/aws/aws-dynamodb/src/client/common/where.ts
@@ -164,6 +164,9 @@ const prepareOperation = (operation: [string, any], schema: AnySchema | undefine
     case 'isNull':
       return [`${path} IS ${value ? 'null' : 'NOT null'}`];
 
+    case 'isMissingOrNull':
+      return [value ? `(${path} IS MISSING OR ${path} IS null)` : `(${path} IS NOT MISSING AND ${path} IS NOT null)`];
+
     case 'startsWith':
       return [`begins_with(${path}, ?)`, value];
 

--- a/providers/aws/aws-dynamodb/test/query-where.spec.ts
+++ b/providers/aws/aws-dynamodb/test/query-where.spec.ts
@@ -173,6 +173,26 @@ describe('dynamodb query (where)', () => {
     deepEqual(variables, []);
   });
 
+  it('assert :: prepare where (is missing or null)', () => {
+    const [whereStatement, variables] = getWhereOperation({
+      bar: { barBar: { isMissingOrNull: true } }
+    });
+
+    equal(whereStatement, `WHERE ("bar"."barBar" IS MISSING OR "bar"."barBar" IS null)`);
+
+    deepEqual(variables, []);
+  });
+
+  it('assert :: prepare where (is not missing or null)', () => {
+    const [whereStatement, variables] = getWhereOperation({
+      bar: { barBar: { isMissingOrNull: false } }
+    });
+
+    equal(whereStatement, `WHERE ("bar"."barBar" IS NOT MISSING AND "bar"."barBar" IS NOT null)`);
+
+    deepEqual(variables, []);
+  });
+
   it('assert :: prepare where (contains)', () => {
     const [whereStatement, variables] = getWhereOperation({
       bar: { barFoo: { contains: 'abc' } }


### PR DESCRIPTION
Combines IS MISSING and IS NULL checks into a single operator. On DynamoDB this avoids the OR boilerplate previously required to match attributes that may be absent or set to null. On PostgreSQL it falls back to IS NULL for regular columns and handles JSONB paths via the key-exists operator.