### PR TITLE
fix(aws-aurora): preserve sub-second precision on date-time and time fields

### DIFF
--- a/providers/aws/aws-aurora/src/client/fields.ts
+++ b/providers/aws/aws-aurora/src/client/fields.ts
@@ -7,6 +7,9 @@ import { UnsupportedFieldTypeError, isJsonFieldSchema } from '@ez4/pgclient';
 import { isDate, isDateTime, isTime, isUUID } from '@ez4/utils';
 import { SchemaType } from '@ez4/schema';
 
+// Data API accepts `HH:MM:SS[.FFF]` for time values and rejects any timezone offset.
+const timePattern = /^\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?/;
+
 export const prepareFieldData = (name: string, value: unknown, schema: AnySchema): SqlParameter => {
   if (isJsonFieldSchema(schema)) {
     return getJsonFieldData(name, value as object);
@@ -149,7 +152,7 @@ const getDateFieldData = (name: string, value: string): SqlParameter => {
 };
 
 const getTimeFieldData = (name: string, value: string): SqlParameter => {
-  const time = value.substring(0, 8);
+  const [time] = timePattern.exec(value) ?? [value.substring(0, 8)];
 
   return {
     typeHint: TypeHint.TIME,
@@ -158,10 +161,10 @@ const getTimeFieldData = (name: string, value: string): SqlParameter => {
 };
 
 const getDateTimeFieldData = (name: string, value: string): SqlParameter => {
-  const timestamp = new Date(value).toISOString().substring(0, 19);
+  const timestamp = new Date(value).toISOString();
 
   const isoDate = timestamp.substring(0, 10);
-  const isoTime = timestamp.substring(11, 19);
+  const isoTime = timestamp.substring(11, 23);
 
   return {
     typeHint: TypeHint.TIMESTAMP,

--- a/providers/aws/aws-aurora/src/client/fields.ts
+++ b/providers/aws/aws-aurora/src/client/fields.ts
@@ -7,8 +7,7 @@ import { UnsupportedFieldTypeError, isJsonFieldSchema } from '@ez4/pgclient';
 import { isDate, isDateTime, isTime, isUUID } from '@ez4/utils';
 import { SchemaType } from '@ez4/schema';
 
-// Data API accepts `HH:MM:SS[.FFF]` for time values and rejects any timezone offset.
-const timePattern = /^\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?/;
+const TIME_PATTERN = /^\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?/;
 
 export const prepareFieldData = (name: string, value: unknown, schema: AnySchema): SqlParameter => {
   if (isJsonFieldSchema(schema)) {
@@ -152,7 +151,7 @@ const getDateFieldData = (name: string, value: string): SqlParameter => {
 };
 
 const getTimeFieldData = (name: string, value: string): SqlParameter => {
-  const [time] = timePattern.exec(value) ?? [value.substring(0, 8)];
+  const time = TIME_PATTERN.exec(value)?.[0] ?? value.substring(0, 8);
 
   return {
     typeHint: TypeHint.TIME,

--- a/providers/aws/aws-aurora/test/client-schema.spec.ts
+++ b/providers/aws/aws-aurora/test/client-schema.spec.ts
@@ -270,7 +270,7 @@ describe('aurora client schema', { timeout: 180000 }, async () => {
 
   it('assert :: insert and select date-time', async () => {
     const id = randomUUID();
-    const datetime = '1991-04-23T23:59:30.000Z';
+    const datetime = '1991-04-23T23:59:30.123Z';
 
     await dbClient.ez4_test_schema.insertOne({
       data: {

--- a/providers/aws/aws-aurora/test/data-detect.spec.ts
+++ b/providers/aws/aws-aurora/test/data-detect.spec.ts
@@ -62,14 +62,38 @@ describe('aurora data detect', { timeout: 180000 }, () => {
     });
   });
 
+  it('assert :: detect time data (with milliseconds)', () => {
+    const data = detectFieldData('field', '23:59:59.123');
+
+    deepEqual(data, {
+      name: 'field',
+      typeHint: 'TIME',
+      value: {
+        stringValue: '23:59:59.123'
+      }
+    });
+  });
+
+  it('assert :: detect time data (with timezone)', () => {
+    const data = detectFieldData('field', '23:59:59.123Z');
+
+    deepEqual(data, {
+      name: 'field',
+      typeHint: 'TIME',
+      value: {
+        stringValue: '23:59:59.123'
+      }
+    });
+  });
+
   it('assert :: detect timestamp data', () => {
-    const data = detectFieldData('field', '1991-04-23T23:59:30.000Z');
+    const data = detectFieldData('field', '1991-04-23T23:59:30.123Z');
 
     deepEqual(data, {
       name: 'field',
       typeHint: 'TIMESTAMP',
       value: {
-        stringValue: '1991-04-23 23:59:30'
+        stringValue: '1991-04-23 23:59:30.123'
       }
     });
   });

--- a/providers/aws/aws-aurora/test/data-prepare.spec.ts
+++ b/providers/aws/aws-aurora/test/data-prepare.spec.ts
@@ -77,8 +77,38 @@ describe('aurora data prepare', () => {
     });
   });
 
+  it('assert :: prepare time data (with milliseconds)', () => {
+    const data = prepareFieldData('field', '23:59:59.123', {
+      type: SchemaType.String,
+      format: 'time'
+    });
+
+    deepEqual(data, {
+      name: 'field',
+      typeHint: 'TIME',
+      value: {
+        stringValue: '23:59:59.123'
+      }
+    });
+  });
+
+  it('assert :: prepare time data (beyond milliseconds)', () => {
+    const data = prepareFieldData('field', '23:59:59.123456', {
+      type: SchemaType.String,
+      format: 'time'
+    });
+
+    deepEqual(data, {
+      name: 'field',
+      typeHint: 'TIME',
+      value: {
+        stringValue: '23:59:59.123'
+      }
+    });
+  });
+
   it('assert :: prepare timestamp data', () => {
-    const data = prepareFieldData('field', '1991-04-23T23:59:30.000Z', {
+    const data = prepareFieldData('field', '1991-04-23T23:59:30.123Z', {
       type: SchemaType.String,
       format: 'date-time'
     });
@@ -87,7 +117,7 @@ describe('aurora data prepare', () => {
       name: 'field',
       typeHint: 'TIMESTAMP',
       value: {
-        stringValue: '1991-04-23 23:59:30'
+        stringValue: '1991-04-23 23:59:30.123'
       }
     });
   });


### PR DESCRIPTION
## Problem

The Data API driver truncates `date-time` values at the second and `time` values at `HH:MM:SS`:

```ts
const getDateTimeFieldData = (name: string, value: string): SqlParameter => {
  const timestamp = new Date(value).toISOString().substring(0, 19); // drops `.sss`
  ...
```

So every timestamp written through the Aurora provider lands in Postgres with `.000`, even though the column is `timestamptz` (microsecond precision) and the source value carries milliseconds. In a production table here, **no row has a non-zero millisecond**. The practical fallout is that any `ORDER BY <datetime>` ties for events within the same second, and Postgres is free to return a different order per read — paginated listings can repeat or skip rows between fetches.

## Why the truncation isn't needed

Both type hints accept an optional fraction ([`SqlParameter` reference](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html)):

> `TIME` — The accepted format is `HH:MM:SS[.FFF]`.
> `TIMESTAMP` — The accepted format is `YYYY-MM-DD HH:MM:SS[.FFF]`.

Verified against a live Data API endpoint (Aurora PostgreSQL 17):

| Sent with `TIMESTAMP` hint | Result |
| --- | --- |
| `2026-07-22T02:17:21.804Z` | ❌ `Parse Error for TimeStamp: input contains invalid characters` |
| `2026-07-22 02:17:21` (current output) | ✅ reads back as `.000` |
| `2026-07-22 02:17:21.804` (this PR) | ✅ reads back as `2026-07-22T02:17:21.804Z` |

What the Data API rejects is the **timezone offset**, not the fraction — so the value is still sent in the space-separated, non-ISO form it expects. This PR only stops cutting the fractional part.

## Consistency

- The **native `pg` driver** already forwards the full ISO string (`libraries/pgclient/src/driver/fields.ts`), so the two drivers currently disagree on precision. This aligns them.
- The **select builder** already reads these columns back via `to_char(..., 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')` (`libraries/pgclient/src/utils/formats.ts`), i.e. it always expected milliseconds — only the write side was lossy.

## Notes

- Fractions are capped at three digits, matching both the documented `[.FFF]` and the precision the select builder reads back. The endpoint does accept six digits, but writing more than the reader returns would make round-trips lossy.
- `time` values keep the existing behaviour of dropping any timezone offset (required — see the table above); the regex falls back to the previous `substring(0, 8)` for values that don't parse.

## Tests

- `data-detect` / `data-prepare`: timestamp assertions now use a non-zero millisecond (`.123`) — the previous `.000Z` fixtures passed either way; added coverage for `time` with milliseconds, with a timezone suffix, and beyond millisecond precision.
- `client-schema`: the `insert and select date-time` round-trip now uses `1991-04-23T23:59:30.123Z`, which fails on `main` and passes here.