### PR TITLE
fix(pgclient): return json as text from the driver, as the data api does

### DIFF
--- a/libraries/pgclient/src/driver/service.ts
+++ b/libraries/pgclient/src/driver/service.ts
@@ -2,7 +2,7 @@ import type { Database, Client as DbClient } from '@ez4/database';
 import type { PgTableRepository } from '@ez4/pgclient/library';
 import type { ClientConnection } from '../types/connection';
 
-import { Pool } from 'pg';
+import { Pool, types } from 'pg';
 
 import { PgClient } from '@ez4/pgclient';
 
@@ -33,8 +33,32 @@ export namespace Client {
   };
 }
 
+/**
+ * Column types this driver hands back as text, because the Data API driver does.
+ *
+ * Both drivers answer the same queries, and `parseRecords` reconciles what they return against the
+ * table schema — which a raw query never has. So for a raw query, whatever the driver returns is
+ * what the caller gets, and the two disagree: `pg` parses JSON into an object, while the Data API
+ * has no such step and returns its text.
+ *
+ * That difference is invisible until deployment. Code written against this driver reads the object,
+ * passes its tests, and then reads a string in front of the other one — where the usual guards
+ * (`Array.isArray`, a cast, a spread) report the value as absent rather than failing.
+ *
+ * Only JSON is normalized here. `pg` also reads timestamps into `Date`, but every datetime the
+ * query builder selects is already rendered by `to_char`, so a raw query is the only place a bare
+ * one appears — and there the divergence is visible: a `Date` is not a string, and code reaching
+ * for one gets an error rather than a wrong answer.
+ */
+const TEXT_TYPES = new Set<number>([types.builtins.JSON, types.builtins.JSONB]);
+
+const getTypeParser = ((oid: number, format?: never) => {
+  return TEXT_TYPES.has(oid) ? (value: string) => value : types.getTypeParser(oid, format);
+}) as typeof types.getTypeParser;
+
 export const createPool = (connection: ClientConnection) => {
   const baseOptions = {
+    types: { getTypeParser },
     allowExitOnIdle: true,
     connectionTimeoutMillis: 5000,
     idleTimeoutMillis: 15000,

--- a/libraries/pgclient/test/client/raw-driver.spec.ts
+++ b/libraries/pgclient/test/client/raw-driver.spec.ts
@@ -58,3 +58,40 @@ describe('client raw driver', () => {
     deepEqual(result, [{ alive: 1 }]);
   });
 });
+
+/**
+ * A raw query has no table schema, so `parseRecords` never runs and whatever the driver returns is
+ * what the caller gets. The Data API driver answers a json column with its text, so this one has to
+ * as well — otherwise code written against a local database reads an object, passes, and then reads
+ * a string in production, where the usual guards report the value as absent instead of failing.
+ */
+describe('client raw driver :: json parity with the data api', () => {
+  const client = Client.make<TestDb>({
+    debug: false,
+    repository: {},
+    connection: {
+      database: 'postgres',
+      password: 'postgres',
+      user: 'postgres',
+      host: '127.0.0.1'
+    }
+  });
+
+  it('assert :: raw query (json column comes back as text)', async () => {
+    const result = await client.rawQuery(`SELECT '{"a":1}'::json AS doc`);
+
+    deepEqual(result, [{ doc: '{"a":1}' }]);
+  });
+
+  it('assert :: raw query (jsonb column comes back as text)', async () => {
+    const result = await client.rawQuery(`SELECT '{"a":1}'::jsonb AS doc`);
+
+    deepEqual(result, [{ doc: '{"a": 1}' }]);
+  });
+
+  it('assert :: raw query (json aggregate comes back as text)', async () => {
+    const result = await client.rawQuery(`SELECT jsonb_agg(to_jsonb(t)) AS docs FROM (SELECT 1 AS v) t`);
+
+    deepEqual(result, [{ docs: '[{"v": 1}]' }]);
+  });
+});


### PR DESCRIPTION
A raw query carries no table schema, so `parseRecords` never runs and whatever the driver returns reaches the caller unchanged. The two drivers disagree there:

| | `@ez4/pgclient/driver` (`pg`) | `@ez4/aws-aurora` (Data API) |
| --- | --- | --- |
| `SELECT '{"a":1}'::jsonb` | `object` `{a: 1}` | `string` `'{"a": 1}'` |

The difference only appears once deployed. Code written against a local database reads the object and passes its tests, then reads a string in front of the Data API — and the guards such code usually carries (`Array.isArray`, a cast, an object spread) report the value as **absent** rather than failing. The query answers with nothing and nothing says why.

## Why this is worth changing rather than documenting

We hit it three times in one day, in three unrelated places:

- an aliases column read as an array — `.length` became a character count, and a string reached an endpoint typed `string[]`
- an aggregate of workflow versions read with `Array.isArray` — every workflow answered with **zero versions**
- an aggregate of a contact's custom fields read through a cast — every template variable pointing at one silently sent its **fallback text**

None raised an error, and none could be caught by a test: against this driver the value is already an object, so the failing shape is the one the test cannot produce. The last one had been shipping wrong text to real contacts.

## Scope

**Only json.** `pg` also reads timestamps into `Date`, but every datetime the query builder selects is already rendered through `to_char`, so a raw query is the only place a bare one appears — and there the divergence is *visible*: a `Date` is not a string, and code reaching for one gets an error rather than a wrong answer. Normalizing those as well changed behaviour without closing a silent failure, so I left them.

The parser is set on the pool rather than through the global `pg` registry, so it cannot reach another `pg` user sharing the process.

## Tests

Three added to `test/client/raw-driver.spec.ts`, covering `json`, `jsonb` and a `jsonb_agg`.

```
with the change     ℹ pass 575   ℹ fail 0
without the change  ℹ pass 572   ℹ fail 3
```

`@ez4/aws-aurora` shows 7 failures both with and without this change — pre-existing on `main` here, they look like they want real AWS credentials.

## Compatibility

This changes what a raw query returns for a json column on the local driver. Anything relying on the parsed object was, by the same token, already reading a string in production — so the code this breaks is the code that was already broken. Happy to split it behind a connection flag instead if you would rather not move the default.
